### PR TITLE
Enforce newlines between operands of ternary expressions

### DIFF
--- a/packages/eslint-config-base/rules/style.js
+++ b/packages/eslint-config-base/rules/style.js
@@ -250,7 +250,7 @@ module.exports = {
     // require multiline ternary
     // https://eslint.org/docs/rules/multiline-ternary
     // TODO: enable?
-    'multiline-ternary': ['off', 'never'],
+    'multiline-ternary': ['error', 'always'],
 
     // require a capital letter for constructors
     'new-cap': ['error', {

--- a/packages/eslint-config-base/rules/style.js
+++ b/packages/eslint-config-base/rules/style.js
@@ -250,7 +250,7 @@ module.exports = {
     // require multiline ternary
     // https://eslint.org/docs/rules/multiline-ternary
     // TODO: enable?
-    'multiline-ternary': ['error', 'always'],
+    'multiline-ternary': ['error', 'always-multiline'],
 
     // require a capital letter for constructors
     'new-cap': ['error', {


### PR DESCRIPTION
Turned on `multiline-ternary` rule.
https://eslint.org/docs/rules/multiline-ternary#enforce-or-disallow-newlines-between-operands-of-ternary-expressions-multiline-ternary