### PR TITLE
Enforce consistent line breaks between braces

### DIFF
--- a/packages/eslint-config-base/rules/style.js
+++ b/packages/eslint-config-base/rules/style.js
@@ -388,10 +388,10 @@ module.exports = {
     // enforce line breaks between braces
     // https://eslint.org/docs/rules/object-curly-newline
     'object-curly-newline': ['error', {
-      ObjectExpression: { minProperties: 4, multiline: true, consistent: true },
-      ObjectPattern: { minProperties: 4, multiline: true, consistent: true },
-      ImportDeclaration: { minProperties: 4, multiline: true, consistent: true },
-      ExportDeclaration: { minProperties: 4, multiline: true, consistent: true },
+      ObjectExpression: { consistent: true },
+      ObjectPattern: { consistent: true },
+      ImportDeclaration: { consistent: true },
+      ExportDeclaration: { consistent: true },
     }],
 
     // enforce "same line" or "multiple line" on object properties.


### PR DESCRIPTION
Updated `object-curly-newline` rule to enforce consistent line breaks between braces.

