### PR TITLE
Enforce standard form react fragment

### DIFF
--- a/packages/eslint-config/rules/react.js
+++ b/packages/eslint-config/rules/react.js
@@ -457,7 +457,7 @@ module.exports = {
 
     // Enforce shorthand or standard form for React fragments
     // https://github.com/yannickcr/eslint-plugin-react/blob/bc976b837abeab1dffd90ac6168b746a83fc83cc/docs/rules/jsx-fragments.md
-    'react/jsx-fragments': ['error', 'syntax'],
+    'react/jsx-fragments': ['error', 'element'],
 
     // Enforce linebreaks in curly braces in JSX attributes and expressions.
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-curly-newline.md


### PR DESCRIPTION
In order to use `<React.Fragment>` shorthand syntax `<>...</>`, we must have to upgrade to Babel 7. If we upgrade to version 7, there is some breaking code in our builder which causes [this issue](https://github.com/babel/babel/discussions/12052). 

We have object rest spread at many places in our code, if we will pass an empty object in `[ ...obj1, ...obj2 ]`, Babel 7 throw the TypeError. Until we add checks everywhere before passing it in  `[ ...obj1, ...obj2 ]`, we will have to use Babel 6.